### PR TITLE
Fix RangeError, and make it a teeny bit faster

### DIFF
--- a/src/quixe/gi_load.js
+++ b/src/quixe/gi_load.js
@@ -742,9 +742,16 @@ var decode_base64;
    of the above.)
 */
 if (window.btoa) {
-    encode_base64 = function(arr) {
-        return window.btoa(String.fromCharCode.apply(this, arr));
-    }
+    encode_base64 = function(image) {
+        // There's a limit on how much can be piped into .apply() at a time, so
+        // do this in chunks
+        var blocks = [];
+        for (var i = 0, l = image.length; i < l; i += 16384) {
+            blocks.push(String.fromCharCode.apply(String, image.slice(i, i + 16384)));
+        }
+
+        return btoa(blocks.join(''));
+    };
 }
 else {
     encode_base64 = function(arr) {

--- a/src/quixe/quixe.js
+++ b/src/quixe/quixe.js
@@ -283,6 +283,9 @@ function Mem4(addr) {
     return (memmap[addr] * 0x1000000) + (memmap[addr+1] * 0x10000) 
         + (memmap[addr+2] * 0x100) + (memmap[addr+3]);
 }
+function MemSlice(addr, length) {
+    return memmap.slice(addr, addr + length);
+}
 function MemW1(addr, val) {
     // ignore high bytes if necessary
     memmap[addr] = val & 0xFF;
@@ -302,6 +305,7 @@ function MemW4(addr, val) {
 self.Mem1 = Mem1;
 self.Mem2 = Mem2;
 self.Mem4 = Mem4;
+self.MemSlice = MemSlice;
 self.MemW1 = MemW1;
 self.MemW2 = MemW2;
 self.MemW4 = MemW4;
@@ -5077,52 +5081,48 @@ self.do_gestalt = do_gestalt;
 /* This fetches a search key, and returns an array containing the key
    (bytewise). Actually it always returns the same array.
 */
-var tempsearchkey = [];
 function fetch_search_key(addr, len, options) {
     var ix;
-    tempsearchkey.length = len;
 
     if (options & 1) {
         /* indirect key */
-        for (ix=0; ix<len; ix++)
-            tempsearchkey[ix] = Mem1(addr+ix);
+        return MemSlice(addr, len);
     }
     else {
         switch (len) {
         case 4:
-            tempsearchkey[0] = (addr >> 24) & 0xFF;
-            tempsearchkey[1] = (addr >> 16) & 0xFF;
-            tempsearchkey[2] = (addr >> 8) & 0xFF;
-            tempsearchkey[3] = addr & 0xFF;
-            break;
+            return [
+                (addr >> 24) & 0xFF,
+                (addr >> 16) & 0xFF,
+                (addr >> 8) & 0xFF,
+                addr & 0xFF
+            ];
         case 2:
-            tempsearchkey[0] = (addr >> 8) & 0xFF;
-            tempsearchkey[1] = addr & 0xFF;
-            break;
+            return [
+                (addr >> 8) & 0xFF,
+                addr & 0xFF
+            ];
         case 1:
-            tempsearchkey[0] = addr & 0xFF;
-            break;
+            return [addr & 0xFF];
         default:
             throw('Direct search key must hold one, two, or four bytes.');
         }
     }
-
-    return tempsearchkey;
 }
 
 function linear_search(key, keysize, start, 
     structsize, numstructs, keyoffset, options) {
 
-    var ix, count, match, byt;
+    var ix, count, match, bytes;
     var retindex = ((options & 4) != 0);
     var zeroterm = ((options & 2) != 0);
     var keybuf = fetch_search_key(key, keysize, options);
 
     for (count=0; count<numstructs; count++, start+=structsize) {
         match = true;
+        bytes = MemSlice(start + keyoffset, keysize);
         for (ix=0; match && ix<keysize; ix++) {
-            byt = Mem1(start + keyoffset + ix);
-            if (byt != keybuf[ix])
+            if (bytes[ix] != keybuf[ix])
                 match = false;
         }
 
@@ -5135,9 +5135,9 @@ function linear_search(key, keysize, start,
         
         if (zeroterm) {
             match = true;
+            bytes = MemSlice(start + keyoffset, keysize);
             for (ix=0; match && ix<keysize; ix++) {
-                byt = Mem1(start + keyoffset + ix);
-                if (byt != 0)
+                if (bytes[ix] != 0)
                     match = false;
             }
             


### PR DESCRIPTION
The RangeError also happens with the 2.1.0 release; I think this commit should apply cleanly there, though.

Times are all load time of Counterfeit Monkey (as given in the console) averaged over three attempts, in current Chromium and current Firefox.

2.1.0 release, after fixing RangeError:
Chromium: 33.758s
Firefox: 16.190s

`noeval`, after fixing RangeError:
Chromium: 18.751s
Firefox: 22.590s

`noeval`, after speeding up `fetch_search_key`:
Chromium: 16.559s
Firefox: 21.783s

So, seems to match your observations — Chrome is significantly faster, Firefox is significantly slower.  Chrome started out doing _really_ badly, though.

I'm not quite sure where to go from here; the VMs are just optimizing differently, and now the bulk of the time is in a handful of functions so it's difficult to see what low-hanging fruit remains.  Chromium blames 28% of the time on `execute_loop` and 18% on `pop_callstub`; Firefox blames 42% (!) on `execute_loop` and 19% on all the dynamically-generated functions in aggregate.

Just for fun, my [original branch](https://github.com/eevee/quixe/commits/super-modernizing), which is kind of a mess:
Chromium: 11.934s
Firefox: 16.242s

The only significant difference I can think of is that I made a VM "class", with all the functions on its _prototype_, and then passed a single instance to generated functions as a regular argument.   It's possible that both JavaScript VMs are just much better at dealing with this pattern, since it's how new types are generally implemented.